### PR TITLE
Add support for extensions defined as functions

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -13,6 +13,7 @@ await Bun.build({
         if (args.path.endsWith('.json')) {
           return null; // default handling = bundle it
         }
+
         return { path: args.path, external: true };
       });
     }

--- a/src/__tests__/client/client-model-extension.test.ts
+++ b/src/__tests__/client/client-model-extension.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeAll } from "vitest"
 
 describe("client-model-extension", () => {
   describe("model extension", async () => {
-    it("should work", async () => {
+    it("should work with extension definition as object", async () => {
       const prismock = await createPrismock()
 
       const extensions = {
@@ -23,6 +23,38 @@ describe("client-model-extension", () => {
           },
         }
       }
+
+      const extendedPrismock = prismock.$extends(extensions)
+
+      const users = extendedPrismock.user.findManyExtended()
+
+      expect(users).toHaveLength(1)
+      expect(users[0]).toMatchObject({
+        id: process.env.TEST_DB_TYPE === "mongodb" ? "1" : 1,
+        email: "extendedClient@foobar.com",
+      })
+    })
+    
+    it("should work with extension definition as function", async () => {
+      const prismock = await createPrismock()
+
+      const extensions = Prisma.defineExtension((client) => {
+        return client.$extends({
+          model: {
+            user: {
+              findManyExtended: () => {
+                const user = mockDeep<Prisma.$UserPayload['scalars']>({
+                  // @ts-expect-error - id is a string in mongodb and a number in postgres
+                  id: process.env.TEST_DB_TYPE === "mongodb" ? "1" : 1,
+                  email: "extendedClient@foobar.com",
+                })
+        
+                return [user]
+              },
+            },
+          }
+        })
+      })
 
       const extendedPrismock = prismock.$extends(extensions)
 

--- a/src/lib/extensions/model.ts
+++ b/src/lib/extensions/model.ts
@@ -7,8 +7,10 @@ export function applyModelExtensions(
   client: PrismaClient,
   extensions: ExtensionsDefinition,
 ): PrismaClient {
-  if (typeof extensions === 'function') {
-    return client;
+  if (typeof extensions === "function") {
+    type ExtendableClient = Parameters<typeof extensions>[0]
+    const extendedClient = extensions(client as ExtendableClient)
+    return extendedClient as PrismaClient
   }
 
   const model = extensions.model ?? {};

--- a/src/lib/extensions/query.ts
+++ b/src/lib/extensions/query.ts
@@ -7,7 +7,9 @@ export function applyQueryExtensions(
   extensions: Parameters<ExtendsHook<"define", Prisma.TypeMapCb, DefaultArgs>>[0],
 ): PrismaClient {
   if (typeof extensions === "function") {
-    return client
+    type ExtendableClient = Parameters<typeof extensions>[0]
+    const extendedClient = extensions(client as ExtendableClient)
+    return extendedClient as PrismaClient
   }
 
   const queryExtendedModelMap = extensions.query ?? {}

--- a/src/lib/extensions/result.ts
+++ b/src/lib/extensions/result.ts
@@ -160,7 +160,9 @@ export function applyResultExtensions(
   extensions: Parameters<ExtendsHook<"define", Prisma.TypeMapCb, DefaultArgs>>[0],
 ): PrismaClient {
   if (typeof extensions === "function") {
-    return client
+    type ExtendableClient = Parameters<typeof extensions>[0]
+    const extendedClient = extensions(client as ExtendableClient)
+    return extendedClient as PrismaClient
   }
 
   const resultExtendedModelMap = (extensions.result ?? {}) as ResultExtensionModelMap


### PR DESCRIPTION
Add support for prisma extensions that are defined as functions via `Prisma.defineExtension`